### PR TITLE
Timezone rendering and deployment pipeline updates

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,12 +35,19 @@ jobs:
 
             export PATH="/home/seanpierce/.nvm/versions/node/v25.8.1/bin:$PATH"
 
+            echo "Building Frontend..."
             cd ../introtorhythm_frontend
             npm ci
             npm run build
 
+            echo "Building Chat Server"
             cd ./src/chat
             npx tsc --project tsconfig.server.json
-            pm2 restart chat-server
+
+            if pm2 describe chat-server-staging > /dev/null; then
+              pm2 restart chat-server-staging
+            else
+              pm2 start server.js --name chat-server-staging
+            fi
 
           EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,19 @@ jobs:
 
             export PATH="/home/seanpierce/.nvm/versions/node/v25.8.1/bin:$PATH"
 
+            echo "Building Frontend..."
             cd ../introtorhythm_frontend
             npm ci
             npm run build
 
+            echo "Building Chat Server"
             cd ./src/chat
             npx tsc --project tsconfig.server.json
-            pm2 restart chat-server-prod
+
+            if pm2 describe chat-server-prod > /dev/null; then
+              pm2 restart chat-server-prod
+            else
+              pm2 start server.js --name chat-server-prod
+            fi
 
           EOF

--- a/introtorhythm_backend/api/views/content.py
+++ b/introtorhythm_backend/api/views/content.py
@@ -73,7 +73,7 @@ class GetContentViewSet(viewsets.ViewSet):
             for show in other_shows:
                 if show.start_date_time:
                     # Convert to Pacific Time and format
-                    formatted_time = show.start_date_time.strftime("%I:%M %p")
+                    formatted_time = show.start_date_time.astimezone(PACIFIC).strftime("%I:%M %p")
                 else:
                     formatted_time = "Unknown Time"
                 upcoming_parts.append(f"{show.title} at {formatted_time} {tz_name}")


### PR DESCRIPTION
This update ensures that the timezone is always reflected as "America/ Los Angeles" in content throughout the site. This was previously showing as UTC. Additionally, I noticed some enhancements that could be made to the depoyment actions for staging and production.