### PR TITLE
Release/1.2.0

### DIFF
--- a/introtorhythm_backend/api/urls.py
+++ b/introtorhythm_backend/api/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 from .views.content import get_content
-from .views.schedule import initiate_show
+from .views.schedule import cleanup_pre_recorded_shows, initiate_show
 
 urlpatterns = [
     path('content/', get_content, name="get_content"),
-    path('schedule/initiate-show/', initiate_show, name='initiate_show')
+    path('schedule/initiate-show/', initiate_show, name='initiate_show'),
+    path("schedule/cleanup-pre-recorded-shows/", cleanup_pre_recorded_shows, name='cleanup_pre_recorded_shows')
 ]

--- a/introtorhythm_backend/api/views/schedule.py
+++ b/introtorhythm_backend/api/views/schedule.py
@@ -8,10 +8,10 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 
 from api.authentication import InternalAPIKeyAuthentication
-from schedule.services.ezstream_scheduler import run_pre_recorded_show_scheduler
+from schedule.services.ezstream_scheduler import cleanup_old_pre_recorded_shows, run_pre_recorded_show_scheduler
 
 
-@api_view(["GET"])
+@api_view(["POST"])
 @authentication_classes([InternalAPIKeyAuthentication])
 @throttle_classes([AnonRateThrottle])
 def initiate_show(request):
@@ -25,3 +25,14 @@ def initiate_show(request):
         return Response(result, status=status.HTTP_200_OK)
 
     return Response(result, status=status.HTTP_200_OK)
+
+
+@api_view(["POST"])
+@authentication_classes([InternalAPIKeyAuthentication])
+@throttle_classes([AnonRateThrottle])
+def cleanup_pre_recorded_shows(request):
+    """
+    Deletes pre-recorded show audio files for shows older than one week. This is a maintenance task that is periodically invoked by cron.
+    """
+    result = cleanup_old_pre_recorded_shows()
+    return Response(result)

--- a/introtorhythm_backend/schedule/models/show.py
+++ b/introtorhythm_backend/schedule/models/show.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.dispatch import receiver
-import pytz
 
 from schedule.helpers import TIMES, DURATION
 

--- a/introtorhythm_backend/schedule/services/ezstream_scheduler.py
+++ b/introtorhythm_backend/schedule/services/ezstream_scheduler.py
@@ -17,6 +17,7 @@ This module is designed to be executed through an authenticated internal
 API endpoint that is periodically invoked by cron.
 """
 
+from datetime import timedelta
 import os
 import signal
 import subprocess
@@ -240,4 +241,44 @@ def run_pre_recorded_show_scheduler():
         "show_id": show.id,
         "audio": file_name,
         "config": str(CONFIG_PATH)
+    }
+
+def cleanup_old_pre_recorded_shows():
+    """
+    Deletes pre-recorded show audio files for shows older than one week.
+
+    For each matching Show:
+    - Confirms a pre-recorded file is assigned.
+    - Deletes the file from storage.
+    - Clears the FileField on the model.
+    - Saves the updated Show record.
+    """
+
+    cutoff = timezone.localtime() - timedelta(days=7)
+
+    old_shows = Show.objects.filter(
+        active=True,
+        pre_recorded_show__isnull=False,
+        start_date_time__lt=cutoff,
+    ).exclude(
+        pre_recorded_show=""
+    )
+
+    deleted = []
+
+    for show in old_shows:
+        file_name = show.pre_recorded_show.name
+
+        show.pre_recorded_show.delete(save=False)
+        show.pre_recorded_show = None
+        show.save(update_fields=["pre_recorded_show"])
+
+        deleted.append({
+            "show_id": show.id,
+            "file": file_name,
+        })
+
+    return {
+        "deleted_count": len(deleted),
+        "deleted": deleted,
     }


### PR DESCRIPTION
A follow up to 1.1.0, this release creates a data retention process for purging files from older shows that are no longer needed on the server. 

This models the "init scheduled show" process introduced in the previous release (1.1.0). 